### PR TITLE
Fix nul characters in `compileinfo.h` and `buildinfo.h`

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,13 +17,10 @@ export FLEUR_LIBRARIES="-L${PREFIX}/lib;-lfftw3;-lxml2;-lblas;-llapack;-lscalapa
 cd build/include
 ls
 
-sed -n '/\x0/ { s/\x0/<NUL>/g; p}' buildinfo.h
 sed -n '/\x0/ { s/\x0/<NUL>/g; p}' compileinfo.h
 
-sed 's/\x0//g' buildinfo.h > buildinfo.h
 sed 's/\x0//g' compileinfo.h > compileinfo.h
 
-sed -n '/\x0/ { s/\x0/<NUL>/g; p}' buildinfo.h
 sed -n '/\x0/ { s/\x0/<NUL>/g; p}' compileinfo.h
 
 cd -

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,7 +14,21 @@ export FLEUR_LIBRARIES="-L${PREFIX}/lib;-lfftw3;-lxml2;-lblas;-llapack;-lscalapa
 #export CFLAGS="${CFLAGS} -I$"
 ./configure.sh
 
-cd build; make; cd -
+cd build
+
+echo "Before"
+grep -Pa '\x00' --color=never include/buildinfo.h | cat -vET
+grep -Pa '\x00' --color=never include/compileinfo.h | cat -vET
+
+sed 's/\x0//g' include/buildinfo.h > include/buildinfo.h
+sed 's/\x0//g' include/compileinfo.h > include/compileinfo.h
+
+echo "After"
+grep -Pa '\x00' --color=never include/buildinfo.h | cat -vET
+grep -Pa '\x00' --color=never include/compileinfo.h | cat -vET
+
+make
+cd -
 
 mkdir -p ${PREFIX}/bin
 cp build/fleur_MPI ${PREFIX}/bin

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -16,16 +16,14 @@ export FLEUR_LIBRARIES="-L${PREFIX}/lib;-lfftw3;-lxml2;-lblas;-llapack;-lscalapa
 
 cd build
 
-echo "Before"
-grep -Pa '\x00' --color=never include/buildinfo.h | cat -vET
-grep -Pa '\x00' --color=never include/compileinfo.h | cat -vET
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/buildinfo.h
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/compileinfo.h
 
 sed 's/\x0//g' include/buildinfo.h > include/buildinfo.h
 sed 's/\x0//g' include/compileinfo.h > include/compileinfo.h
 
-echo "After"
-grep -Pa '\x00' --color=never include/buildinfo.h | cat -vET
-grep -Pa '\x00' --color=never include/compileinfo.h | cat -vET
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/buildinfo.h
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/compileinfo.h
 
 make
 cd -

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -17,16 +17,14 @@ export FLEUR_LIBRARIES="-L${PREFIX}/lib;-lfftw3;-lxml2;-lblas;-llapack;-lscalapa
 cd build/include
 ls
 
+cat -v compileinfo.h
 sed -n '/\x0/ { s/\x0/<NUL>/g; p}' compileinfo.h
 
 sed 's/\x0//g' compileinfo.h > compileinfo.h
 
 sed -n '/\x0/ { s/\x0/<NUL>/g; p}' compileinfo.h
 
-cd -
-
-make
-cd -
+cd -; cd build; make; cd -
 
 mkdir -p ${PREFIX}/bin
 cp build/fleur_MPI ${PREFIX}/bin

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -14,16 +14,19 @@ export FLEUR_LIBRARIES="-L${PREFIX}/lib;-lfftw3;-lxml2;-lblas;-llapack;-lscalapa
 #export CFLAGS="${CFLAGS} -I$"
 ./configure.sh
 
-cd build
+cd build/include
+ls
 
-sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/buildinfo.h
-sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/compileinfo.h
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' buildinfo.h
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' compileinfo.h
 
-sed 's/\x0//g' include/buildinfo.h > include/buildinfo.h
-sed 's/\x0//g' include/compileinfo.h > include/compileinfo.h
+sed 's/\x0//g' buildinfo.h > buildinfo.h
+sed 's/\x0//g' compileinfo.h > compileinfo.h
 
-sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/buildinfo.h
-sed -n '/\x0/ { s/\x0/<NUL>/g; p}' include/compileinfo.h
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' buildinfo.h
+sed -n '/\x0/ { s/\x0/<NUL>/g; p}' compileinfo.h
+
+cd -
 
 make
 cd -

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: b022793360c198e18f269541152a04189990c0bf8326939f0f24bb8ca2adf757
 
 build:
-  number: 0
+  number: 1
   skip: True  # [not linux]
 
 requirements:


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
