### PR TITLE
Pin openmpi to <=4.1.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,12 +29,12 @@ requirements:
     - libblas
     - liblapack
     - libgomp
-    - openmpi
+    - openmpi <=4.1.2
     - scalapack
     - libxml2
     - fftw
   run:
-    - openmpi
+    - openmpi <=4.1.2
     - scalapack
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     remove_nul_characters_compileinfo.patch
 
 build:
-  number: 1
+  number: 2
   skip: True  # [not linux]
 
 requirements:


### PR DESCRIPTION
For newer versions `libmpi_mpifh.so.40: cannot open shared object file: No such file or directory` is thrown

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
