### PR TITLE
Correct nul character patch

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
     remove_nul_characters_compileinfo.patch
 
 build:
-  number: 2
+  number: 3
   skip: True  # [not linux]
 
 requirements:

--- a/recipe/remove_nul_characters_compileinfo.patch
+++ b/recipe/remove_nul_characters_compileinfo.patch
@@ -1,5 +1,5 @@
 diff --git a/init/compile_descr.F90 b/init/compile_descr.F90
-index 039ab6dfb..34dd8e980 100644
+index 039ab6dfb..6d2756070 100644
 --- a/init/compile_descr.F90
 +++ b/init/compile_descr.F90
 @@ -45,6 +45,31 @@ CONTAINS
@@ -25,7 +25,7 @@ index 039ab6dfb..34dd8e980 100644
 +
 +         pos = index( string, achar(0) )
 +         if ( pos > 0 ) then
-+            removenuls = string(1:pos)
++            removenuls = string(1:pos-1)
 +         else
 +            removenuls = string
 +         endif


### PR DESCRIPTION
The removal was off by one, i.e. one nul character remained

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
