### PR TITLE
Relax openmpi pin, all cf 4.1.* versions have libmpi_mpifh.so.40

### DIFF
--- a/.ci_support/migrations/libxml2211.yaml
+++ b/.ci_support/migrations/libxml2211.yaml
@@ -1,7 +1,0 @@
-__migrator:
-  build_number: 1
-  kind: version
-  migration_number: 1
-libxml2:
-- '2.11'
-migrator_ts: 1684203491.9767957

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
   sha256: 7c7943b22043b991ed8c379662cbe8295e4679013fbd70a1ff36db8984595d4a
 
 build:
-  number: 3
+  number: 4
   skip: true  # [win]
 
 requirements:
@@ -27,7 +27,7 @@ requirements:
     - pytest
     - masci-tools
   host:
-    - openmpi <=4.1.2
+    - openmpi <4.2
     - scalapack
     - libblas  # [osx]
     - openblas * *openmp*  # [linux]
@@ -38,7 +38,7 @@ requirements:
     - fftw
     - hdf5 * *openmpi*
   run:
-    - openmpi <=4.1.2
+    - openmpi <4.2
     - scalapack
     - libblas  # [osx]
     - libblas * *openblas  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,7 +27,7 @@ requirements:
     - pytest
     - masci-tools
   host:
-    - openmpi <4.2
+    - openmpi <=4.1
     - scalapack
     - libblas  # [osx]
     - openblas * *openmp*  # [linux]
@@ -38,7 +38,7 @@ requirements:
     - fftw
     - hdf5 * *openmpi*
   run:
-    - openmpi <4.2
+    - openmpi <=4.1
     - scalapack
     - libblas  # [osx]
     - libblas * *openblas  # [linux]


### PR DESCRIPTION
Relax openmpi pin, all cf 4.1.* versions have libmpi_mpifh.so.40 (related to https://github.com/conda-forge/fleur-feedstock/pull/4)
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
